### PR TITLE
修复一个已知的问题

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "tool.xfy9326.keyblocker"
         minSdkVersion 16
         targetSdkVersion 25
-        versionCode 3
-        versionName '1.2'
+        versionCode 4
+        versionName '1.3'
     }
     buildTypes {
         release {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "tool.xfy9326.keyblocker"
         minSdkVersion 16
         targetSdkVersion 25
-        versionCode 4
-        versionName '1.3'
+        versionCode 5
+        versionName '1.4'
     }
     buildTypes {
         release {

--- a/app/src/main/java/tool/xfy9326/keyblocker/GuideActivity.java
+++ b/app/src/main/java/tool/xfy9326/keyblocker/GuideActivity.java
@@ -39,7 +39,8 @@ public class GuideActivity extends Activity {
                 startActivity(intent);
             }
         });
-        CheckBox volume = (CheckBox) findViewById(R.id.checkbox_volume_button_blocked);
+        final CheckBox volume = (CheckBox) findViewById(R.id.checkbox_volume_button_blocked);
+        volume.setEnabled(sp.getBoolean("EnabledCustomKeycode", false));
         volume.setChecked(sp.getBoolean("VolumeButton_Block", false));
         volume.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             public void onCheckedChanged(CompoundButton cb, boolean b) {
@@ -79,6 +80,7 @@ public class GuideActivity extends Activity {
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                 sped.putBoolean("EnabledCustomKeycode", isChecked);
                 sped.commit();
+                volume.setEnabled(isChecked);
                 showToast(isChecked);
             }
         });

--- a/app/src/main/java/tool/xfy9326/keyblocker/KeyBlockService.java
+++ b/app/src/main/java/tool/xfy9326/keyblocker/KeyBlockService.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import static android.view.KeyEvent.ACTION_UP;
 
 public class KeyBlockService extends AccessibilityService {
-    private boolean KeyBlocked = false;
+    private boolean KeyBlocked = true;
     private ButtonBroadcastReceiver bbr = null;
     private Notification.Builder notification = null;
     private SharedPreferences sp = null;
@@ -42,7 +42,7 @@ public class KeyBlockService extends AccessibilityService {
         if (!QuickSettingControl) {
             ShowNotification();
         }
-        sped.putBoolean("KeyBlocked", KeyBlocked);
+        sped.putBoolean("KeyBlocked", true);
         sped.commit();
         super.onServiceConnected();
     }

--- a/app/src/main/java/tool/xfy9326/keyblocker/KeyBlockService.java
+++ b/app/src/main/java/tool/xfy9326/keyblocker/KeyBlockService.java
@@ -70,13 +70,12 @@ public class KeyBlockService extends AccessibilityService {
             }
         }
 
-        if (sp.getBoolean("VolumeButton_Block", false)) {
-            if (keycode == KeyEvent.KEYCODE_VOLUME_UP || keycode == KeyEvent.KEYCODE_VOLUME_MUTE || keycode == KeyEvent.KEYCODE_VOLUME_DOWN) {
-                return true;
-            }
-        }
-
         if (sp.getBoolean("EnabledCustomKeycode", false)) {
+            if (sp.getBoolean("VolumeButton_Block", false)) {
+                if (keycode == KeyEvent.KEYCODE_VOLUME_UP || keycode == KeyEvent.KEYCODE_VOLUME_MUTE || keycode == KeyEvent.KEYCODE_VOLUME_DOWN) {
+                    return true;
+                }
+            }
             String[] sourceStrArray = sp.getString("CustomKeycode", "").split(" ");
             Arrays.sort(sourceStrArray);
             int index = Arrays.binarySearch(sourceStrArray, String.valueOf(keycode));

--- a/app/src/main/res/layout/activity_guide_layout.xml
+++ b/app/src/main/res/layout/activity_guide_layout.xml
@@ -65,8 +65,7 @@
         android:id="@+id/btn_setting_custom"
         android:layout_width="wrap_content"
         android:layout_height="40dp"
-        android:layout_alignBottom="@+id/checkbox_enabled_custom"
-        android:layout_alignTop="@+id/checkbox_enabled_custom"
+        android:layout_alignBaseline="@+id/checkbox_enabled_custom"
         android:layout_toEndOf="@+id/checkbox_enabled_custom"
         android:layout_toRightOf="@+id/checkbox_enabled_custom"
         android:padding="0dp"
@@ -83,14 +82,14 @@
         android:layout_below="@+id/checkbox_testKeycode"
         android:text="@string/enabled_custom" />
 
-
     <CheckBox
         android:id="@+id/checkbox_volume_button_blocked"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentLeft="true"
         android:layout_alignParentStart="true"
-        android:layout_below="@+id/checkbox_force_notification_control"
+        android:layout_below="@+id/checkbox_enabled_custom"
+        android:enabled="false"
         android:text="@string/volumebutton_block" />
 
     <CheckBox
@@ -108,6 +107,6 @@
         android:layout_height="wrap_content"
         android:layout_alignParentLeft="true"
         android:layout_alignParentStart="true"
-        android:layout_below="@+id/checkbox_volume_button_blocked"
+        android:layout_below="@+id/checkbox_force_notification_control"
         android:text="@string/test_keycode" />
 </RelativeLayout>


### PR DESCRIPTION
修改音量键的时候漏改了一个地方,导致默认不屏蔽按键...
现在的规则是,默认屏蔽所有按键,开启自定义屏蔽时可直接屏蔽音量键.